### PR TITLE
Updating to v7 API, Linking Task's Title to Message URL, and Adding Message's Body to a Note on the Task

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,17 +7,17 @@ This script if for people who use Apple Mail and Todoist Premium.
 
 * Creating Todoist taks based on selected Apple Mail message.
 * Using subject of the message as a task name.
-* Adding link to the message as task note. You can open email by one click in Todoist.
+* Adding link to the message as task note & linking the task's title. You can open email by one click in Todoist.
 * Removing prefixes like "Re: " from subject.
 * Possibility of changing task name in dialog window.
+* Appending the email's body to a note on the task.
 * Moving processed message to e.g. "Archive folder.
 
 ##Installing:
 
 * Copy applescript to folder ~/Library/Scripts/Applications/Mail. Create this folder if it doesn't exist.
-* Create in the same directory file todoist-token.txt containing Todoist API token. You can find it in Todoist settings. 
+* Open the script in the Script Editor and add your personal Todoist API token. You can find it in Todoist settings. 
 * Activate script menu in menubar, e.g. http://www.twdesigns.com/how_to/how_to_reveal_applescript_menu.php.
-* You can set token file hidden to unclutter script menu.
 * Using Mail select any message, click script menu and pick the script name. 
 
 


### PR DESCRIPTION
Here's the changes that I've made:

* Changed to Todoist's v7 API endpoint, and updated the JSON response check
* Linked the task's title to the message's URL for faster clicking across devices
* Adding the message's body to a note on the task
* Moved the Todoist API variable into the script, to remove the need for the external file requirement
* Updated the README.md to compensate for the changes

Let me know if any of this causes you issues and I can accommodate changes on my end.

Thanks for the repo!